### PR TITLE
Support configuration for the issuer location.

### DIFF
--- a/nixos/modules/private-storage.nix
+++ b/nixos/modules/private-storage.nix
@@ -56,6 +56,14 @@ in
         The port number on which to service storage clients.
       '';
     };
+    services.private-storage.issuerRootURL = lib.mkOption
+    { default = "https://issuer.privatestorage.io/";
+      type = lib.types.str;
+      example = lib.literalExample "https://example.invalid/";
+      description = ''
+        The URL of the Ristretto issuer service to announce.
+      '';
+    };
   };
 
   # Define configuration based on values given for our options - starting with
@@ -96,9 +104,8 @@ in
           # Turn on our plugin.
           plugins = "privatestorageio-zkapauthz-v1";
         };
-        # It doesn't have any configuration *yet*.
         "storageserver.plugins.privatestorageio-zkapauthz-v1" =
-        {
+        { "ristretto-issuer-root-url" = cfg.issuerRootURL;
         };
       };
     };


### PR DESCRIPTION
This allows configuration for the Tahoe-LAFS storage server so that it can announce the location of the issuer API.  Clients can then read the location from the announcement and use it to perform API calls to interact with the Ristretto-based PrivacyPass protocol.
