### PR TITLE
End-to-end with ristretto

### DIFF
--- a/nixos/modules/issuer.nix
+++ b/nixos/modules/issuer.nix
@@ -14,6 +14,23 @@ in {
         The package to use for the ZKAP issuer.
       '';
     };
+    services.private-storage-issuer.issuer = lib.mkOption {
+      default = "Ristretto";
+      type = lib.types.str;
+      example = lib.literalExample "Trivial";
+      description = ''
+        The issuer algorithm to use.  Either Trivial for a fake no-crypto
+        algorithm or Ristretto for Ristretto-flavored PrivacyPass.
+      '';
+    };
+    services.private-storage-issuer.ristrettoSigningKey = lib.mkOption {
+      default = null;
+      type = lib.types.str;
+      description = ''
+        The Ristretto signing key to use.  Required if the issuer is
+        ``Ristretto``.
+      '';
+    };
   };
 
   config = let
@@ -27,7 +44,14 @@ in {
         after = [ "network.target" ];
 
         serviceConfig = {
-          ExecStart = "${cfg.package}/bin/PaymentServer-exe";
+          ExecStart =
+            let
+              args =
+                if cfg.issuer == "Trivial"
+                  then "--issuer Trivial"
+                  else "--issuer Ristretto --signing-key ${cfg.ristrettoSigningKey}";
+            in
+              "${cfg.package}/bin/PaymentServer-exe ${args}";
           Type = "simple";
           Restart = "always";
         };

--- a/nixos/modules/issuer.nix
+++ b/nixos/modules/issuer.nix
@@ -1,0 +1,36 @@
+# A NixOS module which can run a Ristretto-based issuer for PrivacyStorage
+# ZKAPs.
+{ lib, pkgs, config, ... }: let
+  pspkgs = pkgs.callPackage ./pspkgs.nix { };
+  zkapissuer = pspkgs.callPackage ../pkgs/zkapissuer.nix { };
+in {
+  options = {
+    services.private-storage-issuer.enable = lib.mkEnableOption "PrivateStorage ZKAP Issuer Service";
+    services.private-storage-issuer.package = lib.mkOption {
+      default = zkapissuer.components.exes."PaymentServer-exe";
+      type = lib.types.package;
+      example = lib.literalExample "pkgs.zkapissuer";
+      description = ''
+        The package to use for the ZKAP issuer.
+      '';
+    };
+  };
+
+  config = let
+    cfg = config.services.private-storage-issuer;
+  in
+    lib.mkIf cfg.enable {
+      systemd.services.zkapissuer = {
+        enable = true;
+        description = "ZKAP Issuer";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+
+        serviceConfig = {
+          ExecStart = "${cfg.package}/bin/PaymentServer-exe";
+          Type = "simple";
+          Restart = "always";
+        };
+      };
+    };
+}

--- a/nixos/modules/overlays.nix
+++ b/nixos/modules/overlays.nix
@@ -1,19 +1,38 @@
 let
+  # Define a Python packageOverride that puts our version of Twisted into
+  # python27Packages.
   pythonTwistedOverride = python-self: python-super: {
-    twisted = python-super.callPackage ../pkgs/twisted.nix { inherit (python-super) twisted; };
+    # Get our Twisted derivation.  Pass in the old one so it can have pieces
+    # overridden.  It needs to be passed in explicitly because callPackage is
+    # specially crafted to always pull attributes from the fixed-point.  That
+    # is, `python-self.callPackage` and `python-super.callPackage` will *both*
+    # try to pass `python-self.twisted`.  So we take it upon ourselves to pass
+    # the "correct" Twisted (it is correct because we call its override method
+    # and that never converges if it is the fixed point Twisted).
+    twisted = python-self.callPackage ../pkgs/twisted.nix {
+      inherit (python-super) twisted;
+    };
   };
 in
 self: super: {
+  # Use self.python27 to get the fixed point of all packages (that is, to
+  # respect all of the overrides).  This is important since we want the
+  # overridden Twisted as a dependency of this env, not the original one.
+  #
+  # This might seem to violate the advice to use super for "library
+  # functionality" but python27.buildEnv should be considered a derivation
+  # instead because it implies a whole mess of derivations (all of the Python
+  # modules available).
   privatestorage = self.python27.buildEnv.override
   { extraLibs =
     [ self.python27Packages.tahoe-lafs
       self.python27Packages.zkapauthorizer
     ];
-    # Twisted's dropin.cache always collides between different
-    # plugin-providing packages.
-    # ignoreCollisions = true;
   };
 
+  # Using super.python27 here causes us to define a python27 that overrides
+  # the value from the previously overlay, not from the fixed point.  This is
+  # important because this override never converges.
   python27 = super.python27.override (old: {
     packageOverrides = super.lib.composeExtensions old.packageOverrides pythonTwistedOverride;
   });

--- a/nixos/modules/overlays.nix
+++ b/nixos/modules/overlays.nix
@@ -1,11 +1,20 @@
+let
+  pythonTwistedOverride = python-self: python-super: {
+    twisted = python-super.callPackage ../pkgs/twisted.nix { inherit (python-super) twisted; };
+  };
+in
 self: super: {
-  privatestorage = super.python27.buildEnv.override
+  privatestorage = self.python27.buildEnv.override
   { extraLibs =
-    [ super.python27Packages.tahoe-lafs
-      super.python27Packages.zkapauthorizer
+    [ self.python27Packages.tahoe-lafs
+      self.python27Packages.zkapauthorizer
     ];
     # Twisted's dropin.cache always collides between different
     # plugin-providing packages.
-    ignoreCollisions = true;
+    # ignoreCollisions = true;
   };
+
+  python27 = super.python27.override (old: {
+    packageOverrides = super.lib.composeExtensions old.packageOverrides pythonTwistedOverride;
+  });
 }

--- a/nixos/modules/private-storage.nix
+++ b/nixos/modules/private-storage.nix
@@ -2,16 +2,7 @@
 # preferred configuration for the Private Storage grid.
 { pkgs, lib, config, ... }:
 let
-  # Derive a brand new version of pkgs which has our overlay applied.  The
-  # overlay defines a new version of Tahoe-LAFS and some of its dependencies
-  # and maybe other useful Private Storage customizations.
-  pspkgs = import pkgs.path
-  { overlays = [
-      # needs fetchFromGitHub to check out zkapauthorizer
-      (pkgs.callPackage ./zkap-overlay.nix { })
-      (import ./overlays.nix)
-    ];
-  };
+  pspkgs = pkgs.callPackage ./pspkgs.nix { };
   # Grab the configuration for this module for convenient access below.
   cfg = config.services.private-storage;
 in

--- a/nixos/modules/pspkgs.nix
+++ b/nixos/modules/pspkgs.nix
@@ -4,8 +4,7 @@
 { pkgs }:
 import pkgs.path {
   overlays = [
-    # needs fetchFromGitHub to check out zkapauthorizer
-    (pkgs.callPackage ./zkap-overlay.nix { })
+    (import ./zkap-overlay.nix)
     (import ./overlays.nix)
   ];
 }

--- a/nixos/modules/pspkgs.nix
+++ b/nixos/modules/pspkgs.nix
@@ -1,0 +1,11 @@
+# Derive a brand new version of pkgs which has our overlay applied.  The
+# overlay defines a new version of Tahoe-LAFS and some of its dependencies
+# and maybe other useful Private Storage customizations.
+{ pkgs }:
+import pkgs.path {
+  overlays = [
+    # needs fetchFromGitHub to check out zkapauthorizer
+    (pkgs.callPackage ./zkap-overlay.nix { })
+    (import ./overlays.nix)
+  ];
+}

--- a/nixos/modules/pspkgs.nix
+++ b/nixos/modules/pspkgs.nix
@@ -1,6 +1,6 @@
-# Derive a brand new version of pkgs which has our overlay applied.  The
-# overlay defines a new version of Tahoe-LAFS and some of its dependencies
-# and maybe other useful Private Storage customizations.
+# Derive a brand new version of pkgs which has our overlays applied.  This
+# includes the ZKAPAuthorizer overlay which defines some Python overrides as
+# well as our own which defines the `privatestorage` derivation.
 { pkgs }:
 import pkgs.path {
   overlays = [

--- a/nixos/modules/tests/exercise-storage.py
+++ b/nixos/modules/tests/exercise-storage.py
@@ -1,31 +1,38 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from sys import argv
 from os import urandom
+from subprocess import check_output
+from io import BytesIO
+
+import requests
 
 def main():
     (clientDir,) = argv[1:]
 
     someData = urandom(2 ** 16)
-    with mkstemp() as (fd, name):
-        write(fd, someData)
 
-        cap = get([
-            "tahoe", "-d", clientDir,
-            "put", name,
-        ])
-
-        dataReadBack = get([
-            "tahoe", "-d", clientDir,
-            "get", cap,
-        ])
+    api_root = get_api_root(clientDir)
+    cap = put(api_root, someData)
+    dataReadBack = get(api_root, cap)
 
     assert someData == dataReadBack
 
 
-def get(argv):
-    return check_output(argv)
+def get_api_root(path):
+    with open(path + u"/node.url") as f:
+        return f.read().strip()
+
+def put(api_root, data):
+    response = requests.put(api_root + u"uri", BytesIO(data))
+    response.raise_for_status()
+    return response.text
+
+def get(api_root, cap):
+    response = requests.get(api_root + u"uri/" + cap, stream=True)
+    response.raise_for_status()
+    return response.raw.read()
 
 
-if __name__ == '__main__':
+if __name__ == u'__main__':
     main()

--- a/nixos/modules/tests/exercise-storage.py
+++ b/nixos/modules/tests/exercise-storage.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+#
+# Create a new file via the web interface of a Tahoe-LAFS client node and then
+# retrieve the contents of that file.  Exit with success if the retrieved
+# contents match what was uploaded originally.
+#
+
 from sys import argv
 from os import urandom
 from subprocess import check_output
@@ -23,10 +29,12 @@ def get_api_root(path):
     with open(path + u"/node.url") as f:
         return f.read().strip()
 
+
 def put(api_root, data):
     response = requests.put(api_root + u"uri", BytesIO(data))
     response.raise_for_status()
     return response.text
+
 
 def get(api_root, cap):
     response = requests.get(api_root + u"uri/" + cap, stream=True)

--- a/nixos/modules/tests/exercise-storage.py
+++ b/nixos/modules/tests/exercise-storage.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python2
+
+from sys import argv
+from os import urandom
+
+def main():
+    (clientDir,) = argv[1:]
+
+    someData = urandom(2 ** 16)
+    with mkstemp() as (fd, name):
+        write(fd, someData)
+
+        cap = get([
+            "tahoe", "-d", clientDir,
+            "put", name,
+        ])
+
+        dataReadBack = get([
+            "tahoe", "-d", clientDir,
+            "get", cap,
+        ])
+
+    assert someData == dataReadBack
+
+
+def get(argv):
+    return check_output(argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/nixos/modules/tests/get-passes.py
+++ b/nixos/modules/tests/get-passes.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+#
+# Get a paid voucher and tell the Tahoe-LAFS client node to redeem it for some
+# ZKAPs from an issuer.  Exit with success when the Tahoe-LAFS client node
+# reports that the voucher has been redeemed.
+#
+
 from sys import argv
 from requests import post, get, put
 from json import dumps

--- a/nixos/modules/tests/get-passes.py
+++ b/nixos/modules/tests/get-passes.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+from sys import argv
+from requests import post
+from json import dumps
+
+def main():
+    clientAPIRoot, issuerAPIRoot = argv[1:]
+
+    voucher = "0123456789"
+    zkapauthz = clientAPIRoot + "/storage-plugins/privatestorage-zkapauthorizer-v1"
+
+    # Simulate a payment for a voucher.
+    post(
+        issuerAPIRoot + "/v1/stripe/webhook",
+        dumps(charge_succeeded_json(voucher)),
+    )
+
+    # Tell the client to redeem the voucher.
+    post(
+        zkapauthz + "/voucher",
+        dumps({"voucher": voucher}),
+    )
+
+    # Poll the vouchers list for a while to see it get redeemed.
+    expected = {"number": voucher, "redeemed": True}
+    retry(
+        "find redeemed voucher",
+        lambda: expected == get(zkapauthz + "/voucher/" + voucher),
+    )
+
+
+def retry(description, f):
+    for i in range(60):
+        print("trying to {}...".format(description))
+        if f():
+            print("{} succeeded".format(description))
+            break
+        sleep(1.0)
+    raise ValueError("failed to {} after many tries".format(description))
+
+
+def charge_succeeded_json(voucher):
+    # This structure copy/pasted from Stripe webhook web interface.
+    base_payload = {
+        "id": "evt_1FKSX2DeTd13VRuuhPaUDA2f",
+        "object": "event",
+        "api_version": "2016-07-06",
+        "created": 1568910660,
+        "data": {
+            "object": {
+                "id": "ch_1FKSX2DeTd13VRuuG9BXbqji",
+                "object": "charge",
+                "amount": 999,
+                "amount_refunded": 0,
+                "application": None,
+                "application_fee": None,
+                "application_fee_amount": None,
+                "balance_transaction": "txn_1FKSX2DeTd13VRuuqO1CJZ1e",
+                "billing_details": {
+                    "address": {
+                        "city": None,
+                        "country": None,
+                        "line1": None,
+                        "line2": None,
+                        "postal_code": None,
+                        "state": None
+                    },
+                    "email": None,
+                    "name": None,
+                    "phone": None
+                },
+                "captured": True,
+                "created": 1568910660,
+                "currency": "usd",
+                "customer": None,
+                "description": None,
+                "destination": None,
+                "dispute": None,
+                "failure_code": None,
+                "failure_message": None,
+                "fraud_details": {
+                },
+                "invoice": None,
+                "livemode": False,
+                "metadata": {
+                    "Voucher": None,
+                },
+                "on_behalf_of": None,
+                "order": None,
+                "outcome": {
+                    "network_status": "approved_by_network",
+                    "reason": None,
+                    "risk_level": "normal",
+                    "risk_score": 44,
+                    "seller_message": "Payment complete.",
+                    "type": "authorized"
+                },
+                "paid": True,
+                "payment_intent": None,
+                "payment_method": "card_1FKSX2DeTd13VRuus5VEjmjG",
+                "payment_method_details": {
+                    "card": {
+                        "brand": "visa",
+                        "checks": {
+                            "address_line1_check": None,
+                            "address_postal_code_check": None,
+                            "cvc_check": None
+                        },
+                        "country": "US",
+                        "exp_month": 9,
+                        "exp_year": 2020,
+                        "fingerprint": "HTJeRR4MXhAAkctF",
+                        "funding": "credit",
+                        "last4": "4242",
+                        "three_d_secure": None,
+                        "wallet": None
+                    },
+                    "type": "card"
+                },
+                "receipt_email": None,
+                "receipt_number": None,
+                "receipt_url": "https://pay.stripe.com/receipts/acct_198xN4DeTd13VRuu/ch_1FKSX2DeTd13VRuuG9BXbqji/rcpt_Fq8oAItSiNmcm0beiie6lUYin920E7a",
+                "refunded": False,
+                "refunds": {
+                    "object": "list",
+                    "data": [
+                    ],
+                    "has_more": False,
+                    "total_count": 0,
+                    "url": "/v1/charges/ch_1FKSX2DeTd13VRuuG9BXbqji/refunds"
+                },
+                "review": None,
+                "shipping": None,
+                "source": {
+                    "id": "card_1FKSX2DeTd13VRuus5VEjmjG",
+                    "object": "card",
+                    "address_city": None,
+                    "address_country": None,
+                    "address_line1": None,
+                    "address_line1_check": None,
+                    "address_line2": None,
+                    "address_state": None,
+                    "address_zip": None,
+                    "address_zip_check": None,
+                    "brand": "Visa",
+                    "country": "US",
+                    "customer": None,
+                    "cvc_check": None,
+                    "dynamic_last4": None,
+                    "exp_month": 9,
+                    "exp_year": 2020,
+                    "fingerprint": "HTJeRR4MXhAAkctF",
+                    "funding": "credit",
+                    "last4": "4242",
+                    "metadata": {
+                    },
+                    "name": None,
+                    "tokenization_method": None
+                },
+                "source_transfer": None,
+                "statement_descriptor": None,
+                "statement_descriptor_suffix": None,
+                "status": "succeeded",
+                "transfer_data": None,
+                "transfer_group": None
+            }
+        },
+        "livemode": False,
+        "pending_webhooks": 2,
+        "request": "req_5ozjOIAcOkvVUK",
+        "type": "charge.succeeded"
+    }
+    # Indicate the voucher the payment references.
+    base_payload["data"]["object"]["metadata"]["Voucher"] = voucher
+    return base_payload
+
+
+if __name__ == '__main__':
+    main()

--- a/nixos/modules/tests/get-passes.py
+++ b/nixos/modules/tests/get-passes.py
@@ -49,7 +49,7 @@ def retry(description, f):
         print("trying to {}...".format(description))
         if f():
             print("{} succeeded".format(description))
-            break
+            return
         sleep(1.0)
     raise ValueError("failed to {} after many tries".format(description))
 

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -1,5 +1,6 @@
 let
-  pkgs = import <nixpkgs> { };
+  pkgs = (import <nixpkgs> { });
+  pspkgs = import ../pspkgs.nix { inherit pkgs; };
 
   # Separate helper programs so we can write as little perl inside a string
   # inside a nix expression as possible.
@@ -38,9 +39,11 @@ import <nixpkgs/nixos/tests/make-test.nix> {
     client =
       { config, pkgs, ... }:
       { environment.systemPackages = [
-          pkgs.python2
-          pkgs.tahoe-lafs
           pkgs.daemonize
+          # A Tahoe-LAFS configuration capable of using the right storage
+          # plugin.
+          pspkgs.privatestorage
+          # Support for the tests we'll run.
           (pkgs.python3.withPackages (ps: [ ps.requests ]))
         ];
       } // networkConfig;

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -29,6 +29,7 @@ let
     # I thought we might need to statically asssign IPs but we can just use
     # the node names, "introducer", etc, instead.
     networking.firewall.enable = false;
+    networking.dhcpcd.enable = false;
   };
 in
 # https://nixos.org/nixos/manual/index.html#sec-nixos-tests

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -57,6 +57,7 @@ import <nixpkgs/nixos/tests/make-test.nix> {
         services.private-storage.enable = true;
         services.private-storage.publicIPv4 = "storage";
         services.private-storage.introducerFURL = introducerFURL;
+        services.private-storage.issuerRootURL = "http://issuer/";
       } // networkConfig;
 
     # Operate an issuer as well.

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -124,6 +124,8 @@ import <nixpkgs/nixos/tests/make-test.nix> {
       # Get some ZKAPs from the issuer.
       eval {
         $client->succeed('set -eo pipefail; ${get-passes} http://127.0.0.1:3456 http://issuer:8081 | systemd-cat');
+        # succeed() is not success but 1 is.
+        1;
       } or do {
         my $error = $@ || 'Unknown failure';
         my ($code, $log) = $client->execute('cat /tmp/stdout /tmp/stderr');

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -134,6 +134,15 @@ import <nixpkgs/nixos/tests/make-test.nix> {
       };
 
       # The client should be prepped now.  Make it try to use some storage.
-      $client->succeed('set -eo pipefail; ${exercise-storage} | systemd-cat');
-    '';
+      eval {
+        $client->succeed('set -eo pipefail; ${exercise-storage} /tmp/client | systemd-cat');
+        # nothing succeeds like ... 1.
+        1;
+      } or do {
+        my $error = $@ || 'Unknown failure';
+        my ($code, $log) = $client->execute('cat /tmp/stdout /tmp/stderr');
+        $client->log($log);
+        die $@;
+      };
+      '';
 }

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -118,7 +118,7 @@ import <nixpkgs/nixos/tests/make-test.nix> {
       #
       # Storage appears to be working so try to get a client to speak with it.
       #
-      $client->succeed('${run-client} ${introducerFURL}');
+      $client->succeed('set -eo pipefail; ${run-client} ${introducerFURL} | systemd-cat');
       $client->waitForOpenPort(3456);
 
       # Get some ZKAPs from the issuer.

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -69,7 +69,16 @@ import <nixpkgs/nixos/tests/make-test.nix> {
     { imports =
       [ ../issuer.nix
       ];
-      services.private-storage-issuer.enable = true;
+      services.private-storage-issuer = {
+        enable = true;
+        issuer = "Ristretto";
+        # Notionally, this is a secret key.  This is only the value for this
+        # system test though so I don't care if it leaks to the world at
+        # large.
+        ristrettoSigningKey = "wumQAfSsJlQKDDSaFN/PZ3EbgBit8roVgfzllfCK2gQ=";
+      };
+
+
 
     } // networkConfig;
   };

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -60,7 +60,7 @@ import <nixpkgs/nixos/tests/make-test.nix> {
         services.private-storage.enable = true;
         services.private-storage.publicIPv4 = "storage";
         services.private-storage.introducerFURL = introducerFURL;
-        services.private-storage.issuerRootURL = "http://issuer/";
+        services.private-storage.issuerRootURL = "http://issuer:8081/";
       } // networkConfig;
 
     # Operate an issuer as well.

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -70,14 +70,15 @@ import <nixpkgs/nixos/tests/make-test.nix> {
       [ ../issuer.nix
       ];
       services.private-storage-issuer.enable = true;
-    };
+
+    } // networkConfig;
   };
 
   # Test the machines with a Perl program (sobbing).
   testScript =
     ''
       # Start booting all the VMs in parallel to speed up operations down below.
-      # startAll;
+      startAll;
 
       # Set up a Tahoe-LAFS introducer.
       $introducer->copyFileFromHost(

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -92,9 +92,13 @@ import <nixpkgs/nixos/tests/make-test.nix> {
           '${pemFile}',
           '/tmp/node.pem'
       );
-      $introducer->succeed('set -eo pipefail; ${run-introducer} /tmp/node.pem ${toString introducerPort} ${introducerFURL} | systemd-cat');
+
       eval {
-        $introducer->waitForOpenPort(${toString introducerPort});
+        $introducer->succeed(
+          'set -eo pipefail; ' .
+          '${run-introducer} /tmp/node.pem ${toString introducerPort} ${introducerFURL} | ' .
+          systemd-cat'
+        );
         # Signal success. :/
         1;
       } or do {

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -78,9 +78,6 @@ import <nixpkgs/nixos/tests/make-test.nix> {
         # large.
         ristrettoSigningKey = "wumQAfSsJlQKDDSaFN/PZ3EbgBit8roVgfzllfCK2gQ=";
       };
-
-
-
     } // networkConfig;
   };
 

--- a/nixos/modules/tests/run-client.py
+++ b/nixos/modules/tests/run-client.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+from os import environ
+from sys import argv
+from shutil import which
+from subprocess import check_output
+
+def main():
+    (introducerFURL,) = argv[1:]
+
+    # PYTHONHOME set for Python 3 for this script breaks Python 2 used by
+    # Tahoe. :/ This is kind of a NixOS Python packaging bug.
+    del environ["PYTHONHOME"]
+
+    run(["tahoe", "--version"])
+    run([
+        "tahoe", "create-client",
+        "--shares-needed", "1",
+        "--shares-happy", "1",
+        "--shares-total", "1",
+        "--introducer", introducerFURL,
+        "/tmp/client",
+    ])
+
+    run([
+        "daemonize",
+        "-o", "/tmp/stdout",
+        "-e", "/tmp/stderr",
+        which("tahoe"), "run", "/tmp/client",
+    ])
+
+def run(argv):
+    print("{}: {}".format(argv, check_output(argv)))
+
+
+if __name__ == '__main__':
+    main()

--- a/nixos/modules/tests/run-client.py
+++ b/nixos/modules/tests/run-client.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+#
+# Create a PrivateStorage.io-enabled Tahoe-LAFS client node and run it as a
+# daemon.  Exit with success when we think we've started it.
+#
+
 from os import environ
 from sys import argv
 from shutil import which

--- a/nixos/modules/tests/run-client.py
+++ b/nixos/modules/tests/run-client.py
@@ -4,6 +4,7 @@ from os import environ
 from sys import argv
 from shutil import which
 from subprocess import check_output
+from configparser import ConfigParser
 
 def main():
     (introducerFURL,) = argv[1:]
@@ -21,6 +22,18 @@ def main():
         "--introducer", introducerFURL,
         "/tmp/client",
     ])
+
+    # Add necessary ZKAPAuthorizer configuration bits.
+    config = ConfigParser()
+    with open("/tmp/client/tahoe.cfg") as cfg:
+        config.read_file(cfg)
+
+    config.set(u"client", u"storage.plugins", u"privatestorageio-zkapauthz-v1")
+    config.add_section(u"storageclient.plugins.privatestorageio-zkapauthz-v1")
+    config.set(u"storageclient.plugins.privatestorageio-zkapauthz-v1", u"redeemer", u"ristretto")
+
+    with open("/tmp/client/tahoe.cfg", "wt") as cfg:
+        config.write(cfg)
 
     run([
         "daemonize",

--- a/nixos/modules/tests/run-introducer.py
+++ b/nixos/modules/tests/run-introducer.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+#
+# Create a Tahoe-LAFS introducer node and run it as a daemon.  Exit with
+# success when it is accepting introducer client connections.
+#
+
 from sys import argv
 from os import environ, makedirs, rename
 from shutil import which

--- a/nixos/modules/tests/run-introducer.py
+++ b/nixos/modules/tests/run-introducer.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+from sys import argv
+from os import environ, makedirs, rename
+from shutil import which
+from subprocess import check_output
+from socket import socket
+from time import sleep
+
+log = print
+
+def main():
+    pemFile, introducerPort, introducerFURL = argv[1:]
+
+    # PYTHONHOME set for Python 3 for this script breaks Python 2 used by
+    # Tahoe. :/ This is kind of a NixOS Python packaging bug.
+    del environ["PYTHONHOME"]
+
+    run(["tahoe", "--version"])
+    run([
+        "tahoe", "create-introducer",
+        "--port", "tcp:" + introducerPort,
+        "--location", "tcp:introducer:" + introducerPort,
+        "/tmp/introducer",
+    ])
+    rename(pemFile, "/tmp/introducer/private/node.pem")
+    with open("/tmp/introducer/private/introducer.furl", "w") as f:
+        f.write(introducerFURL)
+    run([
+        "daemonize",
+        "-o", "/tmp/stdout",
+        "-e", "/tmp/stderr",
+        which("tahoe"), "run", "/tmp/introducer",
+    ])
+
+    retry(
+        "waiting for open introducer port",
+        lambda: checkOpen(35151),
+    )
+
+
+def checkOpen(portNumber):
+    s = socket()
+    try:
+        s.connect(("127.0.0.1", portNumber))
+    except:
+        return False
+    else:
+        return True
+    finally:
+        s.close()
+
+
+def retry(description, f):
+    for i in range(60):
+        log("trying to {}...".format(description))
+        if f():
+            log("{} succeeded".format(description))
+            return
+        sleep(1.0)
+    raise ValueError("failed to {} after many tries".format(description))
+
+
+def run(argv):
+    log("Running {}".format(argv))
+    log("{}: {}".format(argv, check_output(argv)))
+
+
+if __name__ == '__main__':
+    main()

--- a/nixos/modules/tests/run-introducer.py
+++ b/nixos/modules/tests/run-introducer.py
@@ -35,7 +35,7 @@ def main():
 
     retry(
         "waiting for open introducer port",
-        lambda: checkOpen(35151),
+        lambda: checkOpen(int(introducerPort)),
     )
 
 

--- a/nixos/modules/zkap-overlay.nix
+++ b/nixos/modules/zkap-overlay.nix
@@ -1,5 +1,4 @@
-{ fetchFromGitHub }:
 let
-  zkapauthorizer = import ../pkgs/zkapauthorizer-repo.nix { inherit fetchFromGitHub; };
+  zkapauthorizer = import ../pkgs/zkapauthorizer-repo.nix;
 in
   import "${zkapauthorizer}/overlays.nix"

--- a/nixos/pkgs/twisted.nix
+++ b/nixos/pkgs/twisted.nix
@@ -1,7 +1,11 @@
 { twisted }:
 twisted.overrideAttrs (old: {
-  version = old.version + "-0";
   prePatch = old.patchPhase;
   patchPhase = null;
+  # Add a patch which adds more logging to a namer resolver failure case.  The
+  # NixOS system test harness might be setting up a weird semi-broken system
+  # that provokes a weird behavior out of getaddrinfo() that Twisted doesn't
+  # normally handle.  The logging can help with debugging this case.  We
+  # should think about upstreaming something related to this.
   patches = (if old ? "patches" then old.patches else []) ++ [ ./twisted.patch ];
 })

--- a/nixos/pkgs/twisted.nix
+++ b/nixos/pkgs/twisted.nix
@@ -1,0 +1,7 @@
+{ twisted }:
+twisted.overrideAttrs (old: {
+  version = old.version + "-0";
+  prePatch = old.patchPhase;
+  patchPhase = null;
+  patches = (if old ? "patches" then old.patches else []) ++ [ ./twisted.patch ];
+})

--- a/nixos/pkgs/twisted.patch
+++ b/nixos/pkgs/twisted.patch
@@ -1,0 +1,23 @@
+diff --git a/src/twisted/internet/_resolver.py b/src/twisted/internet/_resolver.py
+index 1c16174a2..8c8249db4 100644
+--- a/src/twisted/internet/_resolver.py
++++ b/src/twisted/internet/_resolver.py
+@@ -74,6 +74,8 @@ class GAIResolver(object):
+     L{getaddrinfo} in a thread.
+     """
+ 
++    _log = Logger()
++
+     def __init__(self, reactor, getThreadPool=None, getaddrinfo=getaddrinfo):
+         """
+         Create a L{GAIResolver}.
+@@ -124,6 +126,9 @@ class GAIResolver(object):
+                                          socketType)
+             except gaierror:
+                 return []
++            except Exception as e:
++                self._log.failure("Problem resolving {hostName}", hostName=hostName)
++                return []
+         d = deferToThreadPool(self._reactor, pool, get)
+         resolution = HostResolution(hostName)
+         resolutionReceiver.resolutionBegan(resolution)

--- a/nixos/pkgs/zkapauthorizer-repo.nix
+++ b/nixos/pkgs/zkapauthorizer-repo.nix
@@ -1,7 +1,9 @@
-{ fetchFromGitHub }:
-fetchFromGitHub {
-  owner = "PrivateStorageio";
-  repo = "ZKAPAuthorizer";
-  rev = "36dd4c2cffa2e9df651dda4c9ac8977bafe2ed64";
-  sha256 = "sha256:1i5nli73gk56r5brmimcd97dkf7wd4mf6viw4vbcssa7xj6s84af";
-}
+let
+  pkgs = import <nixpkgs> {};
+in
+  pkgs.fetchFromGitHub {
+    owner = "PrivateStorageio";
+    repo = "ZKAPAuthorizer";
+    rev = "00387ea1d02a5800ff4480a3a177ecc87b34532f";
+    sha256 = "053bzpq68fz1y0qzyryxjmbpvpzshhxhkp404pviqdi18xyqgzyc";
+  }

--- a/nixos/pkgs/zkapauthorizer.nix
+++ b/nixos/pkgs/zkapauthorizer.nix
@@ -1,5 +1,5 @@
-{ fetchFromGitHub, python27Packages }:
+{ python27Packages }:
 let
-  zkapauthorizer = import ./zkapauthorizer-repo.nix { inherit fetchFromGitHub; };
+  zkapauthorizer = import ./zkapauthorizer-repo.nix;
 in
   python27Packages.callPackage "${zkapauthorizer}/zkapauthorizer.nix" { }

--- a/nixos/pkgs/zkapissuer.nix
+++ b/nixos/pkgs/zkapissuer.nix
@@ -1,0 +1,10 @@
+{ fetchFromGitHub, callPackage }:
+let
+  paymentServer = fetchFromGitHub {
+    owner = "PrivateStorage";
+    repo = "PaymentServer";
+    rev = "6fbaac7a14d2a03b74e10a4a82b1147ee1dd7d49";
+    sha256 = "0z8mqmns3fqbjy765830s5q6lhz3lxmslxahjc155jsv5b46gjip";
+  };
+in
+  (callPackage "${paymentServer}/nix" { }).PaymentServer

--- a/nixos/pkgs/zkapissuer.nix
+++ b/nixos/pkgs/zkapissuer.nix
@@ -1,7 +1,7 @@
 { fetchFromGitHub, callPackage }:
 let
   paymentServer = fetchFromGitHub {
-    owner = "PrivateStorage";
+    owner = "PrivateStorageio";
     repo = "PaymentServer";
     rev = "6fbaac7a14d2a03b74e10a4a82b1147ee1dd7d49";
     sha256 = "0z8mqmns3fqbjy765830s5q6lhz3lxmslxahjc155jsv5b46gjip";


### PR DESCRIPTION
This adds a Nix-based system test that creates an issuer and tahoe-lafs client, introducer, and storage nodes.  It has the tahoe-lafs client node connect to the tahoe-lafs storage node via the tahoe-lafs introducer and then redeem a voucher with the issuer for ZKAPs.  Finally, it uses the ZKAPs to authorize a write to the storage server and then verifies it can read the data back.
