### PR TITLE
Deploy PaymentServer with Stripe API key

### DIFF
--- a/morph/grid.config.json
+++ b/morph/grid.config.json
@@ -1,5 +1,6 @@
 { "publicStoragePort": 8898
 , "ristrettoSigningKeyPath": "../../PrivateStorageSecrets/ristretto.signing-key"
+, "stripeSecretKeyPath": "../../PrivateStorageSecrets/stripe.secret"
 , "issuerDomain": "payments.privatestorage.io"
 , "letsEncryptAdminEmail": "jean-paul@privatestorage.io"
 }

--- a/morph/issuer.nix
+++ b/morph/issuer.nix
@@ -1,5 +1,6 @@
 { hardware
 , ristrettoSigningKeyPath
+, stripeSecretKeyPath
 , issuerDomain
 , letsEncryptAdminEmail
 , stateVersion
@@ -27,6 +28,7 @@
     enable = true;
     # XXX This should be passed as a path.
     ristrettoSigningKey = builtins.readFile (./.. + ristrettoSigningKeyPath);
+    stripeSecretKeyPath = ./.. + stripeSecretKeyPath;
     database = "SQLite3";
     databasePath = "/var/db/vouchers.sqlite3";
     inherit letsEncryptAdminEmail;

--- a/morph/testing-grid.config.json
+++ b/morph/testing-grid.config.json
@@ -1,5 +1,6 @@
 { "publicStoragePort": 8898
 , "ristrettoSigningKeyPath": "../../PrivateStorageSecrets/ristretto.signing-key"
+, "stripeSecretKeyPath": "../../PrivateStorageSecrets/stripe.secret"
 , "issuerDomain": "payments.privatestorage-staging.com"
 , "letsEncryptAdminEmail": "jean-paul@privatestorage.io"
 }

--- a/nixos/modules/issuer.nix
+++ b/nixos/modules/issuer.nix
@@ -49,6 +49,13 @@ in {
         ``Ristretto``.
       '';
     };
+    services.private-storage-issuer.stripeSecretKeyPath = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        The path to a file containing a Stripe secret key to use for charge
+        and payment management.
+      '';
+    };
     services.private-storage-issuer.database = lib.mkOption {
       default = "Memory";
       type = lib.types.enum [ "Memory" "SQLite3" ];
@@ -124,8 +131,9 @@ in {
             else
               # Only for automated testing.
               "--http-port 80";
+          stripeArgs = "--stripe-key ${builtins.readFile cfg.stripeSecretKeyPath}";
         in
-          "${cfg.package}/bin/PaymentServer-exe ${issuerArgs} ${databaseArgs} ${httpsArgs}";
+          "${cfg.package}/bin/PaymentServer-exe ${issuerArgs} ${databaseArgs} ${httpsArgs} ${stripeArgs}";
     };
 
     # Certificate renewal.  We must declare that we *require* it in our

--- a/nixos/modules/tests/private-storage.nix
+++ b/nixos/modules/tests/private-storage.nix
@@ -17,6 +17,9 @@ let
   # world at large.
   ristrettoSigningKey = "wumQAfSsJlQKDDSaFN/PZ3EbgBit8roVgfzllfCK2gQ=";
 
+  # Ugh.
+  stripeSecretKey = "sk_test_blubblub";
+
   # Here are the preconstructed secrets which we can assign to the introducer.
   # This is a lot easier than having the introducer generate them and then
   # discovering and configuring the other nodes with them.
@@ -85,6 +88,8 @@ import <nixpkgs/nixos/tests/make-test.nix> {
         tls = false;
         issuer = "Ristretto";
         inherit ristrettoSigningKey;
+        stripeSecretKeyPath = pkgs.writeText "stripe.secret" stripeSecretKey;
+        letsEncryptAdminEmail = "user@example.invalid";
       };
     } // networkConfig;
   };

--- a/nixos/pkgs/zkapissuer-repo.nix
+++ b/nixos/pkgs/zkapissuer-repo.nix
@@ -4,6 +4,6 @@ in
   pkgs.fetchFromGitHub {
     owner = "PrivateStorageio";
     repo = "PaymentServer";
-    rev = "6dfc02e395fbbec2c70a109874227ab21bddbb25";
-    sha256 = "1zc8cxc37zixsh8zcqasvg07rfsravlx0bhnx6zv9c5srm37iqap";
+    rev = "c5651f58ff564f00cfcdb4c73584817b9197f7a6";
+    sha256 = "1gmx4c82h95lkmqdklak3kpj6gkpp57hwc309h4798sclgvp287b";
   }


### PR DESCRIPTION
Bump to PaymentServer with browser-facing Stripe-based charge API and add necessary configuration to run it.
