### PR TITLE
Update PaymentServer and ZKAPAuthorizer and leak fewer secrets

### DIFF
--- a/nixos/pkgs/zkapauthorizer-repo.nix
+++ b/nixos/pkgs/zkapauthorizer-repo.nix
@@ -4,6 +4,6 @@ in
   pkgs.fetchFromGitHub {
     owner = "PrivateStorageio";
     repo = "ZKAPAuthorizer";
-    rev = "b703f99ef9447f41acaa5b7402b29b26ebfb5d94";
-    sha256 = "0xhbznfc27mdkckw8rw1w21pzmqw8haf5j62jfm8yb9n3vaqlchs";
+    rev = "27a2f31e5483fa732785cf550e3beef09d67c398";
+    sha256 = "0chd3x5zvv873jah9z0dj4fpq4ika7i919dfzx53ckf395y69dzm";
   }

--- a/nixos/pkgs/zkapissuer-repo.nix
+++ b/nixos/pkgs/zkapissuer-repo.nix
@@ -4,6 +4,6 @@ in
   pkgs.fetchFromGitHub {
     owner = "PrivateStorageio";
     repo = "PaymentServer";
-    rev = "d6ad0042842ca0501c1e378b19bfdb42d5644223";
-    sha256 = "018ybp83ljdwjn2kv1smkb5rx5h0hgw17a452bsyxdq61ysv4ajv";
+    rev = "967e34f14afed67e0ecd9b383b746f454eb6da97";
+    sha256 = "0vmph0l74ncngzdljqxc87jz3zvzjr03l7z37p5mdvkzm8cjjfj3";
   }


### PR DESCRIPTION
Sundry upgrades plus the Stripe key no longer leaks into the Nix store
