### PR TITLE
Upgrade Tahoe-LAFS on the storage servers

### DIFF
--- a/nixos/modules/overlays.nix
+++ b/nixos/modules/overlays.nix
@@ -1,7 +1,7 @@
 let
   # Define a Python packageOverride that puts our version of some Python
   # packages into python27Packages.
-  pythonPackageOverride = python-self: python-super: {
+  pythonPackageOverride = python-self: python-super: rec {
     # Get our Twisted derivation.  Pass in the old one so it can have pieces
     # overridden.  It needs to be passed in explicitly because callPackage is
     # specially crafted to always pull attributes from the fixed-point.  That

--- a/nixos/modules/overlays.nix
+++ b/nixos/modules/overlays.nix
@@ -1,7 +1,7 @@
 let
-  # Define a Python packageOverride that puts our version of Twisted into
-  # python27Packages.
-  pythonTwistedOverride = python-self: python-super: {
+  # Define a Python packageOverride that puts our version of some Python
+  # packages into python27Packages.
+  pythonPackageOverride = python-self: python-super: {
     # Get our Twisted derivation.  Pass in the old one so it can have pieces
     # overridden.  It needs to be passed in explicitly because callPackage is
     # specially crafted to always pull attributes from the fixed-point.  That
@@ -12,6 +12,10 @@ let
     twisted = python-self.callPackage ../pkgs/twisted.nix {
       inherit (python-super) twisted;
     };
+
+    tahoe-lafs = python-self.callPackage ../pkgs/tahoe-lafs.nix { };
+
+    zkapauthorizer = python-self.callPackage ../pkgs/zkapauthorizer.nix { };
   };
 in
 self: super: {
@@ -38,8 +42,8 @@ self: super: {
   python27 = super.python27.override (old: {
     packageOverrides =
       if old ? packageOverrides then
-        super.lib.composeExtensions old.packageOverrides pythonTwistedOverride
+        super.lib.composeExtensions old.packageOverrides pythonPackageOverride
       else
-        pythonTwistedOverride;
+        pythonPackageOverride;
   });
 }

--- a/nixos/modules/overlays.nix
+++ b/nixos/modules/overlays.nix
@@ -13,9 +13,14 @@ let
       inherit (python-super) twisted;
     };
 
+    # Put in our preferred version of tahoe-lafs as well.
     tahoe-lafs = python-self.callPackage ../pkgs/tahoe-lafs.nix { };
 
-    zkapauthorizer = python-self.callPackage ../pkgs/zkapauthorizer.nix { };
+    # This is handy too...
+    zkapauthorizer = python-self.callPackage ../pkgs/zkapauthorizer.nix {
+      # And explicitly configure it with our preferred version of Tahoe-LAFS.
+      inherit tahoe-lafs;
+    };
   };
 in
 self: super: {
@@ -30,7 +35,9 @@ self: super: {
   # instead because it implies a whole mess of derivations (all of the Python
   # modules available).
   privatestorage = self.python27.buildEnv.override
-  { extraLibs =
+  { # ... for dropin.cache
+    ignoreCollisions = true;
+    extraLibs =
     [ self.python27Packages.tahoe-lafs
       self.python27Packages.zkapauthorizer
     ];

--- a/nixos/modules/pspkgs.nix
+++ b/nixos/modules/pspkgs.nix
@@ -1,19 +1,9 @@
 # Derive a brand new version of pkgs which has our overlays applied.  This
-# includes the ZKAPAuthorizer overlay which defines some Python overrides as
-# well as our own which defines the `privatestorage` derivation.
+# includes our definition of the `privatestorage` derivation, a Python
+# environment with Tahoe-LAFS and ZKAPAuthorizer installed.
 { pkgs }:
 import pkgs.path {
   overlays = [
-    # For some reason the order of these overlays matters.  Maybe it has to do
-    # with our python27 override, I'm not sure.  In the other order, we end up
-    # with two derivations of each of Twisted and treq which conflict with
-    # each other.
     (import ./overlays.nix)
-    # It might be nice to eventually remove this.  ZKAPAuthorizer now
-    # self-applies this overlay without our help.  We only still have it
-    # because it also defines tahoe-lafs which we want to use.  We can't see
-    # tahoe-lafs from the self-applied overlay because that overlay is applied
-    # to ZKAPAuthorizer's nixpkgs, not to the one we're using.
-    (import ./zkap-overlay.nix)
   ];
 }

--- a/nixos/modules/pspkgs.nix
+++ b/nixos/modules/pspkgs.nix
@@ -1,9 +1,4 @@
-# Derive a brand new version of pkgs which has our overlays applied.  This
-# includes our definition of the `privatestorage` derivation, a Python
-# environment with Tahoe-LAFS and ZKAPAuthorizer installed.
+# Derive a brand new version of pkgs which has our overlays applied.  This is
+# where the `privatestorage` derivation is added to nixpkgs.
 { pkgs }:
-import pkgs.path {
-  overlays = [
-    (import ./overlays.nix)
-  ];
-}
+pkgs.extend (import ./overlays.nix)

--- a/nixos/pkgs/tahoe-lafs-repo.nix
+++ b/nixos/pkgs/tahoe-lafs-repo.nix
@@ -1,0 +1,9 @@
+let
+  pkgs = import <nixpkgs> {};
+in
+  pkgs.fetchFromGitHub {
+    owner = "tahoe-lafs";
+    repo = "tahoe-lafs";
+    rev = "23e1223c94330741f5b1dda476c3aeb42c3a012f";
+    sha256 = "1zh37rvkiigciwadgrjvnq9519lap1c260v8593g65qrpc1zwjxz";
+  }

--- a/nixos/pkgs/tahoe-lafs.nix
+++ b/nixos/pkgs/tahoe-lafs.nix
@@ -1,0 +1,5 @@
+{ callPackage }:
+let
+  tahoe-lafs-repo = import ./tahoe-lafs-repo.nix;
+in
+  callPackage "${tahoe-lafs-repo}/nix" { }

--- a/nixos/pkgs/zkapauthorizer-repo.nix
+++ b/nixos/pkgs/zkapauthorizer-repo.nix
@@ -4,6 +4,6 @@ in
   pkgs.fetchFromGitHub {
     owner = "PrivateStorageio";
     repo = "ZKAPAuthorizer";
-    rev = "17d66c052bfd08f8d00301cc431a83c70f05db0f";
-    sha256 = "10ss41lk2mlb3ys7b8dc9dkcdiabkvi8clklkm75llk0g5bkvvss";
+    rev = "333a3e3927a4cf0952447d94ea48d8f07916cf70";
+    sha256 = "1sl3xy7nfs5xw2n5mrjcdpma6v1mk2ldi3kd59ns5aj1wvsdipqh";
   }

--- a/nixos/pkgs/zkapauthorizer-repo.nix
+++ b/nixos/pkgs/zkapauthorizer-repo.nix
@@ -4,6 +4,6 @@ in
   pkgs.fetchFromGitHub {
     owner = "PrivateStorageio";
     repo = "ZKAPAuthorizer";
-    rev = "333a3e3927a4cf0952447d94ea48d8f07916cf70";
-    sha256 = "1sl3xy7nfs5xw2n5mrjcdpma6v1mk2ldi3kd59ns5aj1wvsdipqh";
+    rev = "6cd0c32cc53a9734e2cb7c19a9ad28d479612197";
+    sha256 = "0i1r75471yjj4bfi5814ihrcyjk1zdz8rzm06bngij3n70svqhsm";
   }

--- a/nixos/pkgs/zkapauthorizer.nix
+++ b/nixos/pkgs/zkapauthorizer.nix
@@ -1,9 +1,1 @@
-{ callPackage }:
-let
-  repo = import ./zkapauthorizer-repo.nix;
-  typing = callPackage "${repo}/typing.nix" { };
-  challenge-bypass-ristretto = callPackage "${repo}/python-challenge-bypass-ristretto.nix" { };
-in
-(callPackage "${repo}/zkapauthorizer.nix" {
-    inherit challenge-bypass-ristretto;
-    }).overrideAttrs (old: { doCheck = false; doInstallCheck = false; })
+import "${import ./zkapauthorizer-repo.nix}/default.nix"

--- a/nixos/pkgs/zkapauthorizer.nix
+++ b/nixos/pkgs/zkapauthorizer.nix
@@ -1,0 +1,9 @@
+{ callPackage }:
+let
+  repo = import ./zkapauthorizer-repo.nix;
+  typing = callPackage "${repo}/typing.nix" { };
+  challenge-bypass-ristretto = callPackage "${repo}/python-challenge-bypass-ristretto.nix" { };
+in
+(callPackage "${repo}/zkapauthorizer.nix" {
+    inherit challenge-bypass-ristretto;
+    }).overrideAttrs (old: { doCheck = false; doInstallCheck = false; })


### PR DESCRIPTION
Tahoe-LAFS is being ported to Python 3. This is potentially very disruptive as it will involve changes across the entire codebase.

To bound the risk of the porting enterprise it is beneficial to have real-world testing performed as the porting effort progresses. Every master revision along the way should be correct.